### PR TITLE
Update On Gemfile.lock please correct on main branche.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
-gem "jekyll", ">= 3.6.3"
 GEM
   remote: https://rubygems.org/
   specs:
+gem "jekyll", ">= 3.6.3"
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,4 @@
+gem "jekyll", ">= 3.6.3"
 GEM
   remote: https://rubygems.org/
   specs:


### PR DESCRIPTION
Their was this error message:

Remediation
Upgrade jekyll to version 3.6.3 or later On Gemfile.lock file. For example:
gem "jekyll", ">= 3.6.3"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2018-17567 
More information
moderate severity
Vulnerable versions: < 3.6.3
Patched version: 3.6.3
Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows attackers to access arbitrary files by specifying a symlink in the "include" key in the "_config.yml" file.

I'm not sure i did this right.